### PR TITLE
Improve pcache test coverage

### DIFF
--- a/pcache.py
+++ b/pcache.py
@@ -1,0 +1,30 @@
+import os
+import subprocess
+
+from avocado import Test
+
+class PcacheTest(Test):
+    def setUp(self):
+        """Collect parameters for the pcache script"""
+        self.env_dict = {}
+        for path, key, value in self.params.iteritems():
+            self.env_dict[key] = value
+        self.log.info("env_dict: %s", self.env_dict)
+
+    def run_pcache_script(self):
+        env_vars = ' '.join([f'{key}="{value}"' for key, value in self.env_dict.items()])
+        cmd = f"pwd;{env_vars} {self.params.get('test_script')}"
+        result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+
+        if result.returncode == 0:
+            self.log.info("pcache script completed successfully")
+            self.log.debug(result.stdout)
+        else:
+            self.log.error("pcache script failed: %s", result.stderr)
+            self.fail(result)
+
+    def test(self):
+        self.run_pcache_script()
+
+    def tearDown(self):
+        self.log.info("pcache test finished.")

--- a/pcache.py.data/pcache.sh
+++ b/pcache.py.data/pcache.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -ex
+
+# Default values
+: "${data_crc:=false}"
+: "${gc_percent:=}"
+
+# Remove existing device-mapper targets if they exist
+sudo dmsetup remove pcache_ram0p1 2>/dev/null || true
+sudo dmsetup remove pcache_ram0p2 2>/dev/null || true
+
+# Unload modules if already loaded
+sudo rmmod dm-pcache 2>/dev/null || true
+sudo rmmod brd 2>/dev/null || true
+
+# Load required modules
+sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
+sudo insmod ${linux_path}/drivers/block/brd.ko rd_nr=1 rd_size=$((22*1024*1024))
+
+sudo parted /dev/ram0 mklabel gpt
+sudo sgdisk /dev/ram0 -n 1:1M:+10G
+sudo sgdisk /dev/ram0 -n 2:11G:+10G
+
+dd if=/dev/zero of=/dev/pmem0 bs=1M count=1
+dd if=/dev/zero of=/dev/pmem1 bs=1M count=1
+
+SEC_NR=$(sudo blockdev --getsz /dev/ram0p1)
+echo "0 ${SEC_NR} pcache ${cache_dev0} /dev/ram0p1 writeback ${data_crc}" | sudo dmsetup create pcache_ram0p1
+SEC_NR=$(sudo blockdev --getsz /dev/ram0p2)
+echo "0 ${SEC_NR} pcache ${cache_dev1} /dev/ram0p2 writeback ${data_crc}" | sudo dmsetup create pcache_ram0p2
+
+# Tune GC threshold if provided
+if [[ -n "${gc_percent}" ]]; then
+    sudo dmsetup message pcache_ram0p1 0 gc_percent ${gc_percent}
+    sudo dmsetup message pcache_ram0p2 0 gc_percent ${gc_percent}
+fi
+
+sudo mkfs.xfs -f /dev/mapper/pcache_ram0p1

--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -1,0 +1,17 @@
+linux_path: "/workspace/linux_compile"
+cache_dev0: "/dev/pmem0"
+cache_dev1: "/dev/pmem1"
+
+gc: !mux
+  gc60:
+    gc_percent: "60"
+  gc80:
+    gc_percent: "80"
+
+crc: !mux
+  enable:
+    data_crc: "true"
+  disable:
+    data_crc: "false"
+
+test_script: "./pcache.py.data/pcache.sh"


### PR DESCRIPTION
## Summary
- expand the pcache setup script with data CRC and GC tuning options
- provide muxed YAML variants for crc and gc percentages

## Testing
- `python -m py_compile pcache.py`
- `bash -n pcache.py.data/pcache.sh`


------
https://chatgpt.com/codex/tasks/task_e_683ffbcefd8c8321adeff4edc7a162c6