### PR TITLE
Add pcache xfstests script

### DIFF
--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -14,4 +14,8 @@ crc: !mux
   disable:
     data_crc: "false"
 
-test_script: "./pcache.py.data/pcache.sh"
+test_script: !mux
+  default:
+    test_script: "./pcache.py.data/pcache.sh"
+  xfstests:
+    test_script: "./pcache.py.data/pcache_xfstests.sh"

--- a/pcache.py.data/pcache_xfstests.sh
+++ b/pcache.py.data/pcache_xfstests.sh
@@ -24,12 +24,10 @@ trap cleanup EXIT
 # Prepare pcache devices
 bash ./pcache.py.data/pcache.sh
 
-# Mount devices for xfstests
+# Mount points for xfstests
 sudo mkdir -p "${TEST_MNT}" "${SCRATCH_MNT}"
-sudo mount /dev/mapper/pcache_ram0p1 "${TEST_MNT}"
-sudo mount /dev/mapper/pcache_ram0p2 "${SCRATCH_MNT}"
 
 # Run a basic xfstests case
 cd /workspace/xfstests
-./check generic/001
+./check -g quick -g generic/rw -E ./exclude.exclude
 


### PR DESCRIPTION
## Summary
- add `pcache_xfstests.sh` for running xfstests with pcache
- make pcache YAML choose between default and xfstests scripts
- use defaults for mount points and xfstests path

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684002be7d2c83219dc0d8d7f8218308