### PR TITLE
Make pcache data devices configurable

### DIFF
--- a/pcache.py.data/pcache.sh
+++ b/pcache.py.data/pcache.sh
@@ -4,8 +4,8 @@ set -ex
 # Default values
 : "${data_crc:=false}"
 : "${gc_percent:=}"
-: "${data_dev0:=/dev/ram0p1}"
-: "${data_dev1:=/dev/ram0p2}"
+: "${data_dev0:?data_dev0 not set}"
+: "${data_dev1:?data_dev1 not set}"
 
 dm_name0="pcache_$(basename ${data_dev0})"
 dm_name1="pcache_$(basename ${data_dev1})"

--- a/pcache.py.data/pcache.sh
+++ b/pcache.py.data/pcache.sh
@@ -7,9 +7,12 @@ set -ex
 : "${data_dev0:=/dev/ram0p1}"
 : "${data_dev1:=/dev/ram0p2}"
 
+dm_name0="pcache_$(basename ${data_dev0})"
+dm_name1="pcache_$(basename ${data_dev1})"
+
 # Remove existing device-mapper targets if they exist
-sudo dmsetup remove pcache_ram0p1 2>/dev/null || true
-sudo dmsetup remove pcache_ram0p2 2>/dev/null || true
+sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 
 # Unload modules if already loaded
 sudo rmmod dm-pcache 2>/dev/null || true
@@ -22,14 +25,14 @@ dd if=/dev/zero of=/dev/pmem0 bs=1M count=1
 dd if=/dev/zero of=/dev/pmem1 bs=1M count=1
 
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
-echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create pcache_ram0p1
+echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create "${dm_name0}"
 SEC_NR=$(sudo blockdev --getsz ${data_dev1})
-echo "0 ${SEC_NR} pcache ${cache_dev1} ${data_dev1} writeback ${data_crc}" | sudo dmsetup create pcache_ram0p2
+echo "0 ${SEC_NR} pcache ${cache_dev1} ${data_dev1} writeback ${data_crc}" | sudo dmsetup create "${dm_name1}"
 
 # Tune GC threshold if provided
 if [[ -n "${gc_percent}" ]]; then
-    sudo dmsetup message pcache_ram0p1 0 gc_percent ${gc_percent}
-    sudo dmsetup message pcache_ram0p2 0 gc_percent ${gc_percent}
+    sudo dmsetup message "${dm_name0}" 0 gc_percent ${gc_percent}
+    sudo dmsetup message "${dm_name1}" 0 gc_percent ${gc_percent}
 fi
 
-sudo mkfs.xfs -f /dev/mapper/pcache_ram0p1
+sudo mkfs.xfs -f /dev/mapper/${dm_name0}

--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -1,8 +1,8 @@
 linux_path: "/workspace/linux_compile"
 cache_dev0: "/dev/pmem0"
 cache_dev1: "/dev/pmem1"
-data_dev0: "/dev/ram0p1"
-data_dev1: "/dev/ram0p2"
+data_dev0: "DATA_DEV0_DEFAULT"
+data_dev1: "DATA_DEV1_DEFAULT"
 
 gc: !mux
   gc0:

--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -1,6 +1,8 @@
 linux_path: "/workspace/linux_compile"
 cache_dev0: "/dev/pmem0"
 cache_dev1: "/dev/pmem1"
+data_dev0: "/dev/ram0p1"
+data_dev1: "/dev/ram0p2"
 
 gc: !mux
   gc0:

--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -1,8 +1,8 @@
 linux_path: "/workspace/linux_compile"
 cache_dev0: "/dev/pmem0"
 cache_dev1: "/dev/pmem1"
-data_dev0: "DATA_DEV0_DEFAULT"
-data_dev1: "DATA_DEV1_DEFAULT"
+data_dev0: "/dev/ram0p1"
+data_dev1: "/dev/ram0p2"
 
 gc: !mux
   gc0:

--- a/pcache.py.data/pcache_misc.sh
+++ b/pcache.py.data/pcache_misc.sh
@@ -7,7 +7,9 @@ set -ex
 : "${gc_percent:=}"
 : "${data_dev0:=/dev/ram0p1}"
 
-sudo dmsetup remove pcache_ram0p1 2>/dev/null || true
+dm_name0="pcache_$(basename ${data_dev0})"
+
+sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
@@ -50,45 +52,45 @@ if echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback " | \
     exit 1
 fi
 
-echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create pcache_ram0p1
+echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create ${dm_name0}
 
 # gc_percent message sanity checks
-if sudo dmsetup message pcache_ram0p1 0 gc_percent 91; then
+if sudo dmsetup message ${dm_name0} 0 gc_percent 91; then
     echo "dmsetup message succeeded with gc_percent > 90"
     exit 1
 fi
 
-if sudo dmsetup message pcache_ram0p1 0 gc_percent -1; then
+if sudo dmsetup message ${dm_name0} 0 gc_percent -1; then
     echo "dmsetup message succeeded with negative gc_percent"
     exit 1
 fi
 
-if sudo dmsetup message pcache_ram0p1 0 gc_percent ""; then
+if sudo dmsetup message ${dm_name0} 0 gc_percent ""; then
     echo "dmsetup message succeeded with empty gc_percent"
     exit 1
 fi
 
-if sudo dmsetup message pcache_ram0p1 0 gc_percent bad; then
+if sudo dmsetup message ${dm_name0} 0 gc_percent bad; then
     echo "dmsetup message succeeded with string gc_percent"
     exit 1
 fi
 
 if [[ -n "${gc_percent}" ]]; then
-    sudo dmsetup message pcache_ram0p1 0 gc_percent ${gc_percent}
+    sudo dmsetup message ${dm_name0} 0 gc_percent ${gc_percent}
 fi
 
-sudo mkfs.ext4 -F /dev/mapper/pcache_ram0p1
+sudo mkfs.ext4 -F /dev/mapper/${dm_name0}
 sudo mkdir -p /mnt/pcache
-sudo mount /dev/mapper/pcache_ram0p1 /mnt/pcache
+sudo mount /dev/mapper/${dm_name0} /mnt/pcache
 
 dd if=/dev/urandom of=/mnt/pcache/testfile bs=1M count=10
 orig_md5=$(md5sum /mnt/pcache/testfile | awk '{print $1}')
 sudo umount /mnt/pcache
 
-sudo dmsetup remove pcache_ram0p1
+sudo dmsetup remove ${dm_name0}
 
-echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create pcache_ram0p1
-sudo mount /dev/mapper/pcache_ram0p1 /mnt/pcache
+echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create ${dm_name0}
+sudo mount /dev/mapper/${dm_name0} /mnt/pcache
 new_md5=$(md5sum /mnt/pcache/testfile | awk '{print $1}')
 if [[ "${orig_md5}" != "${new_md5}" ]]; then
     echo "MD5 mismatch after recreate"
@@ -96,13 +98,13 @@ if [[ "${orig_md5}" != "${new_md5}" ]]; then
 fi
 sudo umount /mnt/pcache
 
-fio --name=pcachetest --filename=/dev/mapper/pcache_ram0p1 --rw=randwrite --bs=4k --runtime=10 --time_based=1 --ioengine=sync --direct=1 &
+fio --name=pcachetest --filename=/dev/mapper/${dm_name0} --rw=randwrite --bs=4k --runtime=10 --time_based=1 --ioengine=sync --direct=1 &
 fio_pid=$!
 sleep 2
-sudo dmsetup remove --force pcache_ram0p1 || true
+sudo dmsetup remove --force ${dm_name0} || true
 wait ${fio_pid} || true
 
-sudo dmsetup remove pcache_ram0p1 2>/dev/null || true
+sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 
 # Attempt to recreate with a different data_crc value and expect failure
 if [[ "${data_crc}" == "true" ]]; then
@@ -111,9 +113,9 @@ else
     new_crc=true
 fi
 if echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${new_crc}" | \
-    sudo dmsetup create pcache_ram0p1; then
+    sudo dmsetup create ${dm_name0}; then
     echo "dmsetup create succeeded after data_crc change"
-    sudo dmsetup remove pcache_ram0p1
+    sudo dmsetup remove ${dm_name0}
     exit 1
 fi
 
@@ -126,20 +128,20 @@ sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 dd if=/dev/zero of=${cache_dev0} bs=1M count=1
 
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
-echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create pcache_ram0p1
+echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create ${dm_name0}
 
-sudo mkfs.ext4 -F /dev/mapper/pcache_ram0p1
+sudo mkfs.ext4 -F /dev/mapper/${dm_name0}
 sudo mkdir -p /mnt/pcache
-sudo mount /dev/mapper/pcache_ram0p1 /mnt/pcache
+sudo mount /dev/mapper/${dm_name0} /mnt/pcache
 
 dd if=/dev/urandom of=/mnt/pcache/persistfile bs=1M count=5
 orig_md5=$(md5sum /mnt/pcache/persistfile | awk '{print $1}')
 sudo umount /mnt/pcache
 
-sudo dmsetup message pcache_ram0p1 0 gc_percent 0
+sudo dmsetup message ${dm_name0} 0 gc_percent 0
 
 while true; do
-    status=$(sudo dmsetup status pcache_ram0p1)
+    status=$(sudo dmsetup status ${dm_name0})
     read -ra fields <<< "$status"
     len=${#fields[@]}
     key_head=${fields[$((len - 3))]}
@@ -152,25 +154,25 @@ while true; do
 done
 
 # Record pcache status once the cache is flushed
-status_before_remove=$(sudo dmsetup status pcache_ram0p1)
+status_before_remove=$(sudo dmsetup status ${dm_name0})
 read -ra status_fields <<< "$status_before_remove"
 status_before_len=${#status_fields[@]}
 before_key_head=${status_fields[$((status_before_len - 3))]}
 before_dirty_tail=${status_fields[$((status_before_len - 2))]}
 before_key_tail=${status_fields[$((status_before_len - 1))]}
 
-sudo dmsetup remove pcache_ram0p1
+sudo dmsetup remove ${dm_name0}
 
-echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create pcache_ram0p1
+echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create ${dm_name0}
 # Suspend the newly created pcache device and ensure reload fails
-sudo dmsetup suspend pcache_ram0p1
-if echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup reload pcache_ram0p1; then
+sudo dmsetup suspend ${dm_name0}
+if echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup reload ${dm_name0}; then
     echo "dmsetup reload unexpectedly succeeded"
     exit 1
 fi
-sudo dmsetup resume pcache_ram0p1
+sudo dmsetup resume ${dm_name0}
 # Capture status after recreating pcache
-status_after_create=$(sudo dmsetup status pcache_ram0p1)
+status_after_create=$(sudo dmsetup status ${dm_name0})
 read -ra status_fields <<< "$status_after_create"
 status_after_len=${#status_fields[@]}
 after_key_head=${status_fields[$((status_after_len - 3))]}
@@ -184,7 +186,7 @@ if [[ "${before_key_head}" != "${after_key_head}" ||
     exit 1
 fi
 
-sudo dmsetup remove pcache_ram0p1
+sudo dmsetup remove ${dm_name0}
 
 sudo mount ${data_dev0} /mnt/pcache
 new_md5=$(md5sum /mnt/pcache/persistfile | awk '{print $1}')
@@ -196,8 +198,8 @@ sudo umount /mnt/pcache
 
 dd if=/dev/zero of=${cache_dev0} bs=1M count=10
 
-echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create pcache_ram0p1
-sudo mount /dev/mapper/pcache_ram0p1 /mnt/pcache
+echo "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} writeback ${data_crc}" | sudo dmsetup create ${dm_name0}
+sudo mount /dev/mapper/${dm_name0} /mnt/pcache
 new_md5=$(md5sum /mnt/pcache/persistfile | awk '{print $1}')
 if [[ "${orig_md5}" != "${new_md5}" ]]; then
     echo "MD5 mismatch after recreating pcache"
@@ -205,5 +207,5 @@ if [[ "${orig_md5}" != "${new_md5}" ]]; then
 fi
 sudo umount /mnt/pcache
 
-sudo dmsetup remove pcache_ram0p1 2>/dev/null || true
+sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc.sh
+++ b/pcache.py.data/pcache_misc.sh
@@ -5,7 +5,7 @@ set -ex
 : "${cache_dev0:=/dev/pmem0}"
 : "${data_crc:=false}"
 : "${gc_percent:=}"
-: "${data_dev0:=/dev/ram0p1}"
+: "${data_dev0:?data_dev0 not set}"
 
 dm_name0="pcache_$(basename ${data_dev0})"
 

--- a/pcache.py.data/pcache_xfstests.sh
+++ b/pcache.py.data/pcache_xfstests.sh
@@ -7,6 +7,11 @@ set -ex
 : "${cache_dev1:=/dev/pmem1}"
 : "${data_crc:=false}"
 : "${gc_percent:=}"
+: "${data_dev0:=/dev/ram0p1}"
+: "${data_dev1:=/dev/ram0p2}"
+
+dm_name0="pcache_$(basename ${data_dev0})"
+dm_name1="pcache_$(basename ${data_dev1})"
 
 : "${TEST_MNT:=/mnt/test}"
 : "${SCRATCH_MNT:=/mnt/scratch}"
@@ -14,8 +19,8 @@ set -ex
 cleanup() {
     sudo umount "${TEST_MNT}" 2>/dev/null || true
     sudo umount "${SCRATCH_MNT}" 2>/dev/null || true
-    sudo dmsetup remove pcache_ram0p1 2>/dev/null || true
-    sudo dmsetup remove pcache_ram0p2 2>/dev/null || true
+    sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+    sudo dmsetup remove ${dm_name1} 2>/dev/null || true
     sudo rmmod dm-pcache 2>/dev/null || true
 }
 trap cleanup EXIT

--- a/pcache.py.data/pcache_xfstests.sh
+++ b/pcache.py.data/pcache_xfstests.sh
@@ -7,8 +7,8 @@ set -ex
 : "${cache_dev1:=/dev/pmem1}"
 : "${data_crc:=false}"
 : "${gc_percent:=}"
-: "${data_dev0:=/dev/ram0p1}"
-: "${data_dev1:=/dev/ram0p2}"
+: "${data_dev0:?data_dev0 not set}"
+: "${data_dev1:?data_dev1 not set}"
 
 dm_name0="pcache_$(basename ${data_dev0})"
 dm_name1="pcache_$(basename ${data_dev1})"

--- a/pcache.py.data/pcache_xfstests.sh
+++ b/pcache.py.data/pcache_xfstests.sh
@@ -17,7 +17,6 @@ cleanup() {
     sudo dmsetup remove pcache_ram0p1 2>/dev/null || true
     sudo dmsetup remove pcache_ram0p2 2>/dev/null || true
     sudo rmmod dm-pcache 2>/dev/null || true
-    sudo rmmod brd 2>/dev/null || true
 }
 trap cleanup EXIT
 


### PR DESCRIPTION
## Summary
- expose `data_dev0` and `data_dev1` in `pcache.yaml`
- use `${data_dev0}` and `${data_dev1}` in `pcache.sh`
- remove brd/ram0 setup from pcache scripts
- clean up xfstests cleanup routine

## Testing
- `bash -n pcache.py.data/pcache.sh`
- `bash -n pcache.py.data/pcache_misc.sh`
- `bash -n pcache.py.data/pcache_xfstests.sh`
- `python3 -m py_compile pcache.py`


------
https://chatgpt.com/codex/tasks/task_e_68415e1a5e508321aae6e2e3c8501950