### PR TITLE
Add cache_mode parameter to pcache scripts

### DIFF
--- a/pcache.py.data/pcache.sh
+++ b/pcache.py.data/pcache.sh
@@ -4,6 +4,7 @@ set -ex
 # Default values
 : "${data_crc:=false}"
 : "${gc_percent:=}"
+: "${cache_mode:=writeback}"
 : "${data_dev0:?data_dev0 not set}"
 : "${data_dev1:?data_dev1 not set}"
 
@@ -25,9 +26,9 @@ dd if=/dev/zero of=${cache_dev0} bs=1M count=1
 dd if=/dev/zero of=${cache_dev1} bs=1M count=1
 
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
-sudo dmsetup create "${dm_name0}" --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create "${dm_name0}" --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 SEC_NR=$(sudo blockdev --getsz ${data_dev1})
-sudo dmsetup create "${dm_name1}" --table "0 ${SEC_NR} pcache ${cache_dev1} ${data_dev1} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create "${dm_name1}" --table "0 ${SEC_NR} pcache ${cache_dev1} ${data_dev1} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 
 # Tune GC threshold if provided
 if [[ -n "${gc_percent}" ]]; then

--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -4,6 +4,12 @@ cache_dev1: "/dev/pmem1"
 data_dev0: "/dev/ram0p1"
 data_dev1: "/dev/ram0p2"
 
+cache_mode: !mux
+  writeback:
+    cache_mode: "writeback"
+  writethrough:
+    cache_mode: "writethrough"
+
 gc: !mux
   gc0:
     gc_percent: "0"

--- a/pcache.py.data/pcache_misc.sh
+++ b/pcache.py.data/pcache_misc.sh
@@ -6,6 +6,7 @@ set -ex
 : "${data_crc:=false}"
 : "${gc_percent:=}"
 : "${data_dev0:?data_dev0 not set}"
+: "${cache_mode:=writeback}"
 
 dm_name0="pcache_$(basename ${data_dev0})"
 
@@ -18,7 +19,7 @@ reset_pmem() {
     sync
 }
 
-export linux_path cache_dev0 data_crc gc_percent data_dev0 dm_name0
+export linux_path cache_dev0 data_crc gc_percent data_dev0 cache_mode dm_name0
 export -f reset_pmem
 
 test_dir="$(dirname "$0")/pcache_misc_tests"

--- a/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 

--- a/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 
 echo "DEBUG: case 2 - invalid data_crc should fail"
-if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc invalid"; then
+if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc invalid"; then
     echo "dmsetup create succeeded with invalid data_crc"
     sudo dmsetup remove pcache_invalid
     exit 1

--- a/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 

--- a/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 
 echo "DEBUG: case 4 - empty data_crc should fail"
-if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback"; then
+if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode}"; then
     echo "dmsetup create succeeded with empty data_crc"
     sudo dmsetup remove pcache_invalid
     exit 1

--- a/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 

--- a/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 
 echo "DEBUG: case 6 - cache_mode only"
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 2 cache_mode writeback"
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 2 cache_mode ${cache_mode}"
 sudo dmsetup remove ${dm_name0}

--- a/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 

--- a/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 
 echo "DEBUG: case 8 - invalid number_of_optional_arguments should fail"
-if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} INVAL cache_mode writeback data_crc ${data_crc}"; then
+if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} INVAL cache_mode ${cache_mode} data_crc ${data_crc}"; then
     echo "dmsetup create succeeded with invalid optional args"
     sudo dmsetup remove pcache_invalid
     exit 1
 fi
-if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 100 cache_mode writeback data_crc ${data_crc}"; then
+if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 100 cache_mode ${cache_mode} data_crc ${data_crc}"; then
     echo "dmsetup create succeeded with invalid optional args"
     sudo dmsetup remove pcache_invalid
     exit 1

--- a/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
+++ b/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 
 echo "DEBUG: case 9 - basic create and gc_percent message checks"
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 
 # gc_percent message sanity checks
 if sudo dmsetup message ${dm_name0} 0 gc_percent 91; then

--- a/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
+++ b/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
 
 echo "DEBUG: case 10 - data persistence after remove and recreate"
@@ -13,7 +14,7 @@ sudo umount /mnt/pcache
 
 sudo dmsetup remove ${dm_name0}
 
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 sudo mount /dev/mapper/${dm_name0} /mnt/pcache
 new_md5=$(md5sum /mnt/pcache/testfile | awk '{print $1}')
 if [[ "${orig_md5}" != "${new_md5}" ]]; then

--- a/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
+++ b/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 
 echo "DEBUG: case 11 - remove pcache while fio running"

--- a/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 
 echo "DEBUG: case 12 - dmsetup create should fail after data_crc change"
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 sudo dmsetup remove ${dm_name0}
 
 if [[ "${data_crc}" == "true" ]]; then
@@ -12,7 +13,7 @@ if [[ "${data_crc}" == "true" ]]; then
 else
     new_crc=true
 fi
-if sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${new_crc}"; then
+if sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${new_crc}"; then
     echo "dmsetup create succeeded after data_crc change"
     sudo dmsetup remove ${dm_name0}
     exit 1

--- a/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 
 echo "DEBUG: case 13 - flush cached data and verify persistence"
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 
 sudo mkfs.ext4 -F /dev/mapper/${dm_name0}
 sudo mkdir -p /mnt/pcache
@@ -40,9 +41,9 @@ before_key_tail=${status_fields[$((status_before_len - 1))]}
 
 sudo dmsetup remove ${dm_name0}
 
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 sudo dmsetup suspend ${dm_name0}
-if sudo dmsetup reload ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"; then
+if sudo dmsetup reload ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"; then
     echo "dmsetup reload unexpectedly succeeded"
     exit 1
 fi
@@ -72,7 +73,7 @@ sudo umount /mnt/pcache
 
 reset_pmem
 
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 sudo mount /dev/mapper/${dm_name0} /mnt/pcache
 new_md5=$(md5sum /mnt/pcache/persistfile | awk '{print $1}')
 if [[ "${orig_md5}" != "${new_md5}" ]]; then

--- a/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
+++ b/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -e
+: "${cache_mode:=writeback}"
 reset_pmem
 
 echo "DEBUG: case 14 - verify data consistency under heavy IO"
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 
 sudo mkfs.ext4 -F /dev/mapper/${dm_name0}
 sudo mkdir -p /mnt/pcache
@@ -41,7 +42,7 @@ sync
 sudo umount /mnt/pcache
 sudo dmsetup remove ${dm_name0}
 
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode writeback data_crc ${data_crc}"
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 sudo mount /dev/mapper/${dm_name0} /mnt/pcache
 new_md5=$(md5sum /mnt/pcache/heavyfile | awk '{print $1}')
 if [[ "${orig_md5}" != "${new_md5}" ]]; then

--- a/pcache.py.data/pcache_xfstests.sh
+++ b/pcache.py.data/pcache_xfstests.sh
@@ -7,6 +7,7 @@ set -ex
 : "${cache_dev1:=/dev/pmem1}"
 : "${data_crc:=false}"
 : "${gc_percent:=}"
+: "${cache_mode:=writeback}"
 : "${data_dev0:?data_dev0 not set}"
 : "${data_dev1:?data_dev1 not set}"
 


### PR DESCRIPTION
## Summary
- add `cache_mode` mux option to pcache.yaml
- use `cache_mode` variable when creating dm targets
- export `cache_mode` in helper scripts
- default scripts to `writeback`

## Testing
- `python3 -m py_compile pcache.py cbdctrl.py fio.py xfstests.py all_test.py all_test_quick.py build.py`
- `for f in pcache.py.data/*.sh pcache.py.data/pcache_misc_tests/*.sh; do bash -n $f || exit 1; done`


------
https://chatgpt.com/codex/tasks/task_e_687e4d34a074832197dc756fdedb7fad