### PR TITLE
Update logging for misc pcache tests

### DIFF
--- a/pcache.py.data/pcache_misc.sh
+++ b/pcache.py.data/pcache_misc.sh
@@ -24,9 +24,9 @@ export -f reset_pmem
 test_dir="$(dirname "$0")/pcache_misc_tests"
 
 for tc in "$test_dir"/*.sh; do
-    echo "===== Running $(basename "$tc") ====="
+    echo "===== Running $(basename "$tc") =====" | sudo tee /dev/kmsg
     bash "$tc"
-    echo "===== Finished $(basename "$tc") ====="
+    echo "===== Finished $(basename "$tc") =====" | sudo tee /dev/kmsg
 done
 
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- log start/finish of misc test cases to kmsg

## Testing
- `bash -n pcache.py.data/pcache_misc.sh`
- `shellcheck pcache.py.data/pcache_misc.sh`

------
https://chatgpt.com/codex/tasks/task_e_687f0f2853b08321b0465009a6c845cd