### PR TITLE
Enable debug tracing

### DIFF
--- a/build.py.data/build.sh
+++ b/build.py.data/build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -x
 env
 cd ${kernel_dir}
 

--- a/pcache.py.data/pcache_failslab.sh
+++ b/pcache.py.data/pcache_failslab.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -euxo pipefail
 
 DBG=/sys/kernel/debug/failslab
 PROB=50

--- a/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
+++ b/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
+++ b/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
+++ b/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
+++ b/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"

--- a/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
+++ b/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
-set -e
-set -x
+set -ex
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"


### PR DESCRIPTION
## Summary
- enable debug tracing in script for build
- enable debug tracing in pcache misc tests and failslab script

## Testing
- `bash -n build.py.data/build.sh pcache.py.data/pcache_failslab.sh pcache.py.data/pcache_misc_tests/*.sh`

------
https://chatgpt.com/codex/tasks/task_e_6883216681488321b29db27a19b2a269