### PR TITLE
Add fail_make_request pcache test

### DIFF
--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -30,11 +30,13 @@ crc: !mux
     data_crc: "false"
 
 test_script: !mux
-    default:
-      test_script: "./pcache.py.data/pcache.sh"
-    xfstests:
-      test_script: "./pcache.py.data/pcache_xfstests.sh"
-    misc:
-      test_script: "./pcache.py.data/pcache_misc.sh"
-    failslab:
-      test_script: "./pcache.py.data/pcache_failslab.sh"
+  default:
+    test_script: "./pcache.py.data/pcache.sh"
+  xfstests:
+    test_script: "./pcache.py.data/pcache_xfstests.sh"
+  misc:
+    test_script: "./pcache.py.data/pcache_misc.sh"
+  failslab:
+    test_script: "./pcache.py.data/pcache_failslab.sh"
+  fail_make_request:
+    test_script: "./pcache.py.data/pcache_fail_make_request.sh"

--- a/pcache.py.data/pcache_fail_make_request.sh
+++ b/pcache.py.data/pcache_fail_make_request.sh
@@ -1,6 +1,18 @@
 #!/bin/bash
-: "${cache_mode:=writeback}"
 set -ex
+
+: "${linux_path:=/workspace/linux_compile}"
+: "${cache_dev0:=/dev/pmem0}"
+: "${data_dev0:?data_dev0 not set}"
+: "${cache_mode:=writeback}"
+: "${data_crc:=false}"
+
+DM_NAME="pcache_$(basename ${data_dev0})"
+
+reset_pmem() {
+    dd if=/dev/zero of=${cache_dev0} bs=1M count=1 oflag=direct
+    sync
+}
 
 cleanup() {
     if [[ -n "${MAKE_FAIL_PATH}" ]]; then
@@ -8,26 +20,25 @@ cleanup() {
     fi
     sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/times" 2>/dev/null || true
     sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/verbose" 2>/dev/null || true
-    sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+    sudo dmsetup remove "${DM_NAME}" 2>/dev/null || true
     sudo rmmod dm-pcache 2>/dev/null || true
 }
 trap cleanup EXIT
 
-sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${DM_NAME}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
-if ! sudo dmsetup create ${dm_name0}_probe --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"; then
+if ! sudo dmsetup create ${DM_NAME}_probe --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"; then
     echo "cache_mode ${cache_mode} not supported, skipping"
     exit 0
 fi
-sudo dmsetup remove ${dm_name0}_probe
+sudo dmsetup remove ${DM_NAME}_probe
 reset_pmem
 
-echo "DEBUG: case 20 - simulate backing_dev IO error with fail_make_request"
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
-sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
+sudo dmsetup create ${DM_NAME} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
 
 # configure fail_make_request on the backing device
 sudo sh -c "echo 2 > /sys/kernel/debug/fail_make_request/interval"
@@ -41,38 +52,25 @@ if [[ ! -e ${MAKE_FAIL_PATH} ]]; then
 fi
 sudo sh -c "echo 1 > ${MAKE_FAIL_PATH}"
 
-# read should fail when backing device returns errors
-if dd if=/dev/mapper/${dm_name0} of=/dev/null bs=4k count=1 iflag=direct; then
+# read should fail
+if dd if=/dev/mapper/${DM_NAME} of=/dev/null bs=4k count=1 iflag=direct; then
     echo "read succeeded when fail_make_request is enabled"
-    sudo sh -c "echo 0 > ${MAKE_FAIL_PATH}"
-    sudo dmsetup remove ${dm_name0}
     exit 1
 fi
 
-# determine expected outcome of writes
 expect_write_success=false
 if [[ "${cache_mode}" == "writeback" || "${cache_mode}" == "writeonly" ]]; then
     expect_write_success=true
 fi
 
-# attempt a write through pcache
-if dd if=/dev/zero of=/dev/mapper/${dm_name0} bs=4k count=1 oflag=direct; then
-    if [[ "${expect_write_success}" != true ]]; then
+if dd if=/dev/zero of=/dev/mapper/${DM_NAME} bs=4k count=1 oflag=direct; then
+    [[ "${expect_write_success}" == true ]] || {
         echo "write unexpectedly succeeded for cache_mode ${cache_mode}"
-        sudo sh -c "echo 0 > ${MAKE_FAIL_PATH}"
-        sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/times"
-        sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/verbose"
-        sudo dmsetup remove ${dm_name0}
         exit 1
-    fi
+    }
 else
-    if [[ "${expect_write_success}" == true ]]; then
+    [[ "${expect_write_success}" != true ]] || {
         echo "write unexpectedly failed for cache_mode ${cache_mode}"
-        sudo sh -c "echo 0 > ${MAKE_FAIL_PATH}"
-        sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/times"
-        sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/verbose"
-        sudo dmsetup remove ${dm_name0}
         exit 1
-    fi
+    }
 fi
-

--- a/pcache.py.data/pcache_fail_make_request.sh
+++ b/pcache.py.data/pcache_fail_make_request.sh
@@ -45,11 +45,15 @@ sudo sh -c "echo 2 > /sys/kernel/debug/fail_make_request/interval"
 sudo sh -c "echo 50 > /sys/kernel/debug/fail_make_request/probability"
 sudo sh -c "echo 100 > /sys/kernel/debug/fail_make_request/times"
 sudo sh -c "echo 1 > /sys/kernel/debug/fail_make_request/verbose"
-MAKE_FAIL_PATH="/sys/block/$(basename "${data_dev0}")/make-it-fail"
+MAJ_MIN=$(lsblk -d -no MAJ:MIN "${data_dev0}" | tr -d '[:space:]')
+MAKE_FAIL_PATH="/sys/dev/block/${MAJ_MIN}/make-it-fail"
 if [[ ! -e "${MAKE_FAIL_PATH}" ]]; then
-    parent=$(lsblk -no pkname "${data_dev0}" | head -n 1 | tr -d '[:space:]')
-    if [[ -n "${parent}" ]]; then
-        MAKE_FAIL_PATH="/sys/block/${parent}/$(basename "${data_dev0}")/make-it-fail"
+    MAKE_FAIL_PATH="/sys/block/$(basename "${data_dev0}")/make-it-fail"
+    if [[ ! -e "${MAKE_FAIL_PATH}" ]]; then
+        parent=$(lsblk -no pkname "${data_dev0}" | head -n 1 | tr -d '[:space:]')
+        if [[ -n "${parent}" ]]; then
+            MAKE_FAIL_PATH="/sys/block/${parent}/$(basename "${data_dev0}")/make-it-fail"
+        fi
     fi
 fi
 sudo sh -c "echo 1 > ${MAKE_FAIL_PATH}"

--- a/pcache.py.data/pcache_fail_make_request.sh
+++ b/pcache.py.data/pcache_fail_make_request.sh
@@ -47,7 +47,7 @@ sudo sh -c "echo 100 > /sys/kernel/debug/fail_make_request/times"
 sudo sh -c "echo 1 > /sys/kernel/debug/fail_make_request/verbose"
 MAKE_FAIL_PATH="/sys/block/$(basename ${data_dev0})/make-it-fail"
 if [[ ! -e ${MAKE_FAIL_PATH} ]]; then
-    parent=$(lsblk -no pkname ${data_dev0})
+    parent=$(lsblk -no pkname "${data_dev0}" | head -n 1)
     MAKE_FAIL_PATH="/sys/block/${parent}/$(basename ${data_dev0})/make-it-fail"
 fi
 sudo sh -c "echo 1 > ${MAKE_FAIL_PATH}"

--- a/pcache.py.data/pcache_misc_tests/case20_fail_make_request.sh
+++ b/pcache.py.data/pcache_misc_tests/case20_fail_make_request.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+set -ex
+sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo rmmod dm-pcache 2>/dev/null || true
+sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+: "${cache_mode:=writeback}"
+reset_pmem
+SEC_NR=$(sudo blockdev --getsz ${data_dev0})
+if ! sudo dmsetup create ${dm_name0}_probe --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"; then
+    echo "cache_mode ${cache_mode} not supported, skipping"
+    exit 0
+fi
+sudo dmsetup remove ${dm_name0}_probe
+reset_pmem
+
+echo "DEBUG: case 20 - simulate backing_dev IO error with fail_make_request"
+SEC_NR=$(sudo blockdev --getsz ${data_dev0})
+sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
+
+# configure fail_make_request on the backing device
+sudo sh -c "echo 2 > /sys/kernel/debug/fail_make_request/interval"
+sudo sh -c "echo 50 > /sys/kernel/debug/fail_make_request/probability"
+sudo sh -c "echo 100 > /sys/kernel/debug/fail_make_request/times"
+sudo sh -c "echo 1 > /sys/kernel/debug/fail_make_request/verbose"
+MAKE_FAIL_PATH="/sys/block/$(basename ${data_dev0})/make-it-fail"
+if [[ ! -e ${MAKE_FAIL_PATH} ]]; then
+    parent=$(lsblk -no pkname ${data_dev0})
+    MAKE_FAIL_PATH="/sys/block/${parent}/$(basename ${data_dev0})/make-it-fail"
+fi
+sudo sh -c "echo 1 > ${MAKE_FAIL_PATH}"
+
+# read should fail when backing device returns errors
+if dd if=/dev/mapper/${dm_name0} of=/dev/null bs=4k count=1 iflag=direct; then
+    echo "read succeeded when fail_make_request is enabled"
+    sudo sh -c "echo 0 > ${MAKE_FAIL_PATH}"
+    sudo dmsetup remove ${dm_name0}
+    exit 1
+fi
+
+# determine expected outcome of writes
+expect_write_success=false
+if [[ "${cache_mode}" == "writeback" || "${cache_mode}" == "writeonly" ]]; then
+    expect_write_success=true
+fi
+
+# attempt a write through pcache
+if dd if=/dev/zero of=/dev/mapper/${dm_name0} bs=4k count=1 oflag=direct; then
+    if [[ "${expect_write_success}" != true ]]; then
+        echo "write unexpectedly succeeded for cache_mode ${cache_mode}"
+        sudo sh -c "echo 0 > ${MAKE_FAIL_PATH}"
+        sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/times"
+        sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/verbose"
+        sudo dmsetup remove ${dm_name0}
+        exit 1
+    fi
+else
+    if [[ "${expect_write_success}" == true ]]; then
+        echo "write unexpectedly failed for cache_mode ${cache_mode}"
+        sudo sh -c "echo 0 > ${MAKE_FAIL_PATH}"
+        sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/times"
+        sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/verbose"
+        sudo dmsetup remove ${dm_name0}
+        exit 1
+    fi
+fi
+
+sudo sh -c "echo 0 > ${MAKE_FAIL_PATH}"
+sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/times"
+sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/verbose"
+
+sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo rmmod dm-pcache 2>/dev/null || true


### PR DESCRIPTION
## Summary
- add new misc test `case20_fail_make_request.sh` to simulate backing_dev I/O error using debugfs fail_make_request
- fix make-it-fail path when backing device is a partition

## Testing
- `python3 -m py_compile pcache.py`
- `shellcheck pcache.py.data/pcache_misc_tests/case20_fail_make_request.sh` *(fails with warnings)*

------
https://chatgpt.com/codex/tasks/task_e_688cb763a08483219c746f376174ddc8