### PR TITLE
Remove all pcache devices before module unload

### DIFF
--- a/pcache.py.data/pcache_fail_make_request.sh
+++ b/pcache.py.data/pcache_fail_make_request.sh
@@ -4,10 +4,12 @@ set -ex
 : "${linux_path:=/workspace/linux_compile}"
 : "${cache_dev0:=/dev/pmem0}"
 : "${data_dev0:?data_dev0 not set}"
+: "${data_dev1:?data_dev1 not set}"
 : "${cache_mode:=writeback}"
 : "${data_crc:=false}"
 
 DM_NAME="pcache_$(basename "${data_dev0}")"
+DM_NAME1="pcache_$(basename "${data_dev1}")"
 
 reset_pmem() {
     dd if=/dev/zero of="${cache_dev0}" bs=1M count=1 oflag=direct
@@ -21,6 +23,7 @@ cleanup() {
     sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/times" 2>/dev/null || true
     sudo sh -c "echo 0 > /sys/kernel/debug/fail_make_request/verbose" 2>/dev/null || true
     sudo dmsetup remove "${DM_NAME}" 2>/dev/null || true
+    sudo dmsetup remove "${DM_NAME1}" 2>/dev/null || true
     sudo rmmod dm-pcache 2>/dev/null || true
 
     [[ -n "${TMP_IN}" && -f "${TMP_IN}" ]] && rm -f "${TMP_IN}"
@@ -29,6 +32,7 @@ cleanup() {
 trap cleanup EXIT
 
 sudo dmsetup remove "${DM_NAME}" 2>/dev/null || true
+sudo dmsetup remove "${DM_NAME1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod "${linux_path}"/drivers/md/dm-pcache/dm-pcache.ko
 reset_pmem

--- a/pcache.py.data/pcache_fail_make_request.sh
+++ b/pcache.py.data/pcache_fail_make_request.sh
@@ -26,8 +26,8 @@ cleanup() {
     sudo dmsetup remove "${DM_NAME1}" 2>/dev/null || true
     sudo rmmod dm-pcache 2>/dev/null || true
 
-    [[ -n "${TMP_IN}" && -f "${TMP_IN}" ]] && rm -f "${TMP_IN}"
-    [[ -n "${TMP_OUT}" && -f "${TMP_OUT}" ]] && rm -f "${TMP_OUT}"
+    [[ -n "${TMP_IN}" && -f "${TMP_IN}" ]] && rm -f "${TMP_IN}" || true
+    [[ -n "${TMP_OUT}" && -f "${TMP_OUT}" ]] && rm -f "${TMP_OUT}" || true
 }
 trap cleanup EXIT
 

--- a/pcache.py.data/pcache_failslab.sh
+++ b/pcache.py.data/pcache_failslab.sh
@@ -5,6 +5,7 @@ set -euxo pipefail
 : "${linux_path:=/workspace/linux_compile}"
 : "${cache_dev0:=/dev/pmem0}"
 : "${data_dev0:?data_dev0 not set}"
+: "${data_dev1:?data_dev1 not set}"
 : "${cache_mode:=writeback}"
 : "${data_crc:=false}"
 
@@ -35,6 +36,9 @@ revert_patch() {
 
 cleanup() {
     echo 0 > "$DBG/times" || true
+    sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+    sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
+    sudo rmmod dm-pcache 2>/dev/null || true
     revert_patch
 }
 

--- a/pcache.py.data/pcache_failslab.sh
+++ b/pcache.py.data/pcache_failslab.sh
@@ -39,7 +39,7 @@ cleanup() {
     sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
     sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
     sudo rmmod dm-pcache 2>/dev/null || true
-    revert_patch
+    revert_patch || true
 }
 
 

--- a/pcache.py.data/pcache_misc.sh
+++ b/pcache.py.data/pcache_misc.sh
@@ -8,9 +8,11 @@ set -ex
 : "${data_crc:=false}"
 : "${gc_percent:=}"
 : "${data_dev0:?data_dev0 not set}"
+: "${data_dev1:?data_dev1 not set}"
 : "${cache_mode:=writeback}"
 
 dm_name0="pcache_$(basename ${data_dev0})"
+dm_name1="pcache_$(basename ${data_dev1})"
 
 pmem_a=${cache_dev0}
 pmem_b=${cache_dev1}
@@ -25,6 +27,7 @@ if [[ "${striped}" == "true" ]]; then
 fi
 
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 if [[ "${striped}" == "true" ]]; then
@@ -50,7 +53,7 @@ reset_pmem() {
     sync
 }
 
-export linux_path cache_dev0 data_crc gc_percent data_dev0 cache_mode dm_name0
+export linux_path cache_dev0 data_crc gc_percent data_dev0 data_dev1 cache_mode dm_name0 dm_name1
 export -f reset_pmem
 
 test_dir="$(dirname "$0")/pcache_misc_tests"
@@ -62,4 +65,5 @@ for tc in "$test_dir"/*.sh; do
 done
 
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -21,4 +22,5 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
     exit 1
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -20,4 +21,5 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
     exit 1
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -20,4 +21,5 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
     exit 1
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -20,4 +21,5 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
     exit 1
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -16,4 +17,5 @@ reset_pmem
 echo "DEBUG: case 5 - create without optional arguments"
 sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0}"
 sudo dmsetup remove ${dm_name0}
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -16,4 +17,5 @@ reset_pmem
 echo "DEBUG: case 6 - cache_mode only"
 sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 2 cache_mode ${cache_mode}"
 sudo dmsetup remove ${dm_name0}
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -16,4 +17,5 @@ reset_pmem
 echo "DEBUG: case 7 - data_crc only"
 sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 2 data_crc true"
 sudo dmsetup remove ${dm_name0}
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -25,4 +26,5 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
     exit 1
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
+++ b/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -47,4 +48,5 @@ if sudo dmsetup message ${dm_name0} 0 invalid_cmd 1; then
     exit 1
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
+++ b/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -35,4 +36,5 @@ if [[ "${orig_md5}" != "${new_md5}" ]]; then
 fi
 sudo umount /mnt/pcache
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
+++ b/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -23,4 +24,5 @@ sudo dmsetup remove --force ${dm_name0} || true
 wait ${fio_pid} || true
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -31,4 +32,5 @@ if sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${d
 fi
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -93,4 +94,5 @@ fi
 sudo umount /mnt/pcache
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
+++ b/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -62,4 +63,5 @@ fi
 sudo umount /mnt/pcache
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -31,4 +32,5 @@ if sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${d
 fi
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -52,4 +53,5 @@ if [[ "${orig_md5}" != "${new_md5}" ]]; then
 fi
 sudo umount /mnt/pcache
 
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -60,4 +61,5 @@ fi
 sudo umount /mnt/pcache
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true

--- a/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -72,5 +73,6 @@ fi
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo rm -f "${src_file}" "${read_file}"
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 

--- a/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
+++ b/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -ex
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true
 sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
 : "${cache_mode:=writeback}"
@@ -32,4 +33,5 @@ if [[ "${actual}" != "${expected}" ]]; then
 fi
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 sudo rmmod dm-pcache 2>/dev/null || true


### PR DESCRIPTION
## Summary
- ensure both dm_name0 and dm_name1 are removed before unloading dm-pcache in pcache test scripts
- export additional device names and clean up in failslab and misc tests

## Testing
- `bash -n pcache.py.data/pcache_fail_make_request.sh pcache.py.data/pcache_failslab.sh pcache.py.data/pcache_misc.sh pcache.py.data/pcache_misc_tests/*.sh`

------
https://chatgpt.com/codex/tasks/task_e_688dc505b7c483219df4168acea13188