### PR TITLE
Add covdir parameter and capture gcov during pcache tests

### DIFF
--- a/pcache.py
+++ b/pcache.py
@@ -11,6 +11,8 @@ class PcacheTest(Test):
             self.env_dict[key] = value
         self.striped = str(self.params.get('striped', default='false')).lower()
         self.env_dict['striped'] = self.striped
+        self.gcov = str(self.params.get('gcov', default='false')).lower()
+        self.env_dict['gcov'] = self.gcov
         self.log.info("env_dict: %s", self.env_dict)
 
     def run_pcache_script(self):

--- a/pcache.py.data/pcache.sh
+++ b/pcache.py.data/pcache.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 
@@ -75,3 +76,6 @@ if [[ -n "${gc_percent}" ]]; then
 fi
 
 sudo mkfs.xfs -f /dev/mapper/${dm_name0}
+sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache.sh
+++ b/pcache.py.data/pcache.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache.sh
+++ b/pcache.py.data/pcache.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache.sh
+++ b/pcache.py.data/pcache.sh
@@ -1,6 +1,30 @@
 #!/bin/bash
 set -ex
 
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
+
 # Default values
 : "${striped:=false}"
 : "${data_crc:=false}"
@@ -22,10 +46,10 @@ sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
 
 # Unload modules if already loaded
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod
 
 # Load required modules
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 dd if=/dev/zero of=${cache_dev0} bs=1M count=1 oflag=direct
 dd if=/dev/zero of=${cache_dev1} bs=1M count=1 oflag=direct
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})

--- a/pcache.py.data/pcache.sh
+++ b/pcache.py.data/pcache.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -1,5 +1,6 @@
 linux_path: "/workspace/linux_compile"
 covdir: "/workspace/datatravelguide/covdir"
+gcov: false
 cache_dev0: "/dev/pmem0"
 cache_dev1: "/dev/pmem1"
 cache_dev2: "/dev/pmem2"

--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -1,4 +1,5 @@
 linux_path: "/workspace/linux_compile"
+covdir: "/workspace/datatravelguide/covdir"
 cache_dev0: "/dev/pmem0"
 cache_dev1: "/dev/pmem1"
 cache_dev2: "/dev/pmem2"

--- a/pcache.py.data/pcache_fail_make_request.sh
+++ b/pcache.py.data/pcache_fail_make_request.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_fail_make_request.sh
+++ b/pcache.py.data/pcache_fail_make_request.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_fail_make_request.sh
+++ b/pcache.py.data/pcache_fail_make_request.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_fail_make_request.sh
+++ b/pcache.py.data/pcache_fail_make_request.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_failslab.sh
+++ b/pcache.py.data/pcache_failslab.sh
@@ -2,8 +2,10 @@
 set -euxo pipefail
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_failslab.sh
+++ b/pcache.py.data/pcache_failslab.sh
@@ -6,8 +6,8 @@ set -euxo pipefail
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_failslab.sh
+++ b/pcache.py.data/pcache_failslab.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_failslab.sh
+++ b/pcache.py.data/pcache_failslab.sh
@@ -6,9 +6,10 @@ set -euxo pipefail
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc.sh
+++ b/pcache.py.data/pcache_misc.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc.sh
+++ b/pcache.py.data/pcache_misc.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc.sh
+++ b/pcache.py.data/pcache_misc.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc.sh
+++ b/pcache.py.data/pcache_misc.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -23,4 +47,4 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case01_invalid_cache_mode.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case02_invalid_data_crc.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -22,4 +46,4 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
+++ b/pcache.py.data/pcache_misc_tests/case03_empty_cache_mode.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -22,4 +46,4 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
+++ b/pcache.py.data/pcache_misc_tests/case04_empty_data_crc.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -22,4 +46,4 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case05_create_no_optional_args.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -18,4 +42,4 @@ echo "DEBUG: case 5 - create without optional arguments"
 sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0}"
 sudo dmsetup remove ${dm_name0}
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case06_cache_mode_only.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -18,4 +42,4 @@ echo "DEBUG: case 6 - cache_mode only"
 sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 2 cache_mode ${cache_mode}"
 sudo dmsetup remove ${dm_name0}
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
+++ b/pcache.py.data/pcache_misc_tests/case07_data_crc_only.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -18,4 +42,4 @@ echo "DEBUG: case 7 - data_crc only"
 sudo dmsetup create ${dm_name0} --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 2 data_crc true"
 sudo dmsetup remove ${dm_name0}
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
+++ b/pcache.py.data/pcache_misc_tests/case08_invalid_optional_args.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -27,4 +51,4 @@ if sudo dmsetup create pcache_invalid --table "0 ${SEC_NR} pcache ${cache_dev0} 
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
+++ b/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -49,4 +73,4 @@ if sudo dmsetup message ${dm_name0} 0 invalid_cmd 1; then
 fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
+++ b/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
+++ b/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
+++ b/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
+++ b/pcache.py.data/pcache_misc_tests/case09_gc_percent_checks.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
+++ b/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
+++ b/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
+++ b/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
+++ b/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -37,4 +61,4 @@ fi
 sudo umount /mnt/pcache
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
+++ b/pcache.py.data/pcache_misc_tests/case10_persistence_after_recreate.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
+++ b/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
+++ b/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
+++ b/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
+++ b/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
+++ b/pcache.py.data/pcache_misc_tests/case11_remove_while_fio.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -25,4 +49,4 @@ wait ${fio_pid} || true
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -33,4 +57,4 @@ fi
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case12_fail_after_crc_change.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case13_flush_cache_persistence.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 
@@ -95,4 +119,4 @@ sudo umount /mnt/pcache
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
+++ b/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
+++ b/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
+++ b/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
+++ b/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 
@@ -64,4 +88,4 @@ sudo umount /mnt/pcache
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
+++ b/pcache.py.data/pcache_misc_tests/case14_heavy_io_consistency.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
+++ b/pcache.py.data/pcache_misc_tests/case15_fail_after_cache_mode_change.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 
@@ -33,4 +57,4 @@ fi
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
+++ b/pcache.py.data/pcache_misc_tests/case16_writethrough_persistence.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 
@@ -62,4 +86,4 @@ sudo umount /mnt/pcache
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case17_writearound_behavior.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 
@@ -74,5 +98,4 @@ fi
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo rm -f "${src_file}" "${read_file}"
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
+++ b/pcache.py.data/pcache_misc_tests/case18_writeonly_behavior.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
+++ b/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
+++ b/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
@@ -1,9 +1,33 @@
 #!/bin/bash
 set -ex
+
+: "${covdir:=/workspace/datatravelguide/covdir}"
+
+dump_gcov() {
+    ts=$(date +%s)
+    mkdir -p "$covdir"
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+}
+
+pcache_rmmod() {
+    dump_gcov
+    sudo rmmod dm-pcache 2>/dev/null || true
+}
+
+reset_gcov() {
+    echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
+}
+
+pcache_insmod() {
+    reset_gcov
+    sudo insmod "$1"
+}
+
 sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
-sudo insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko 2>/dev/null || true
+pcache_rmmod
+pcache_insmod ${linux_path}/drivers/md/dm-pcache/dm-pcache.ko
 : "${cache_mode:=writeback}"
 reset_pmem
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
@@ -34,4 +58,4 @@ fi
 
 sudo dmsetup remove ${dm_name0} 2>/dev/null || true
 sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
-sudo rmmod dm-pcache 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
+++ b/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
+++ b/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
+++ b/pcache.py.data/pcache_misc_tests/case19_dmsetup_table_output.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_striped.sh
+++ b/pcache.py.data/pcache_striped.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_striped.sh
+++ b/pcache.py.data/pcache_striped.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_striped.sh
+++ b/pcache.py.data/pcache_striped.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov

--- a/pcache.py.data/pcache_striped.sh
+++ b/pcache.py.data/pcache_striped.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 
@@ -78,3 +79,6 @@ if [[ -n "${gc_percent}" ]]; then
 fi
 
 sudo mkfs.xfs -f /dev/mapper/${dm_name0}
+sudo dmsetup remove "${dm_name0}" 2>/dev/null || true
+sudo dmsetup remove "${dm_name1}" 2>/dev/null || true
+pcache_rmmod

--- a/pcache.py.data/pcache_xfstests.sh
+++ b/pcache.py.data/pcache_xfstests.sh
@@ -6,8 +6,8 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
 }
 
 

--- a/pcache.py.data/pcache_xfstests.sh
+++ b/pcache.py.data/pcache_xfstests.sh
@@ -10,6 +10,7 @@ dump_gcov() {
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
+    reset_gcov
 }
 
 

--- a/pcache.py.data/pcache_xfstests.sh
+++ b/pcache.py.data/pcache_xfstests.sh
@@ -2,8 +2,10 @@
 set -ex
 
 : "${covdir:=/workspace/datatravelguide/covdir}"
+: "${gcov:=false}"
 
 dump_gcov() {
+    [[ "$gcov" != "true" ]] && return
     ts=$(date +%s)
     mkdir -p "$covdir"
     sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$3_$(basename "$1")"' _ {} "$covdir" "$ts" \;
@@ -17,6 +19,7 @@ pcache_rmmod() {
 }
 
 reset_gcov() {
+    [[ "$gcov" != "true" ]] && return
     echo 1 | sudo tee /sys/kernel/debug/gcov/reset >/dev/null
 }
 

--- a/pcache.py.data/pcache_xfstests.sh
+++ b/pcache.py.data/pcache_xfstests.sh
@@ -6,9 +6,10 @@ set -ex
 dump_gcov() {
     ts=$(date +%s)
     mkdir -p "$covdir"
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
-    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'for f; do dest="$covdir/${f#/}.$ts"; mkdir -p "$(dirname "$dest")"; sudo cp "$f" "$dest"; done' sh {} +
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcda" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
+    sudo find /sys/kernel/debug/gcov -path "*dm-pcache*gcno" -exec sh -c 'cp "$1" "$2/$(basename "$1").$3"' _ {} "$covdir" "$ts" \;
 }
+
 
 pcache_rmmod() {
     dump_gcov


### PR DESCRIPTION
## Summary
- add configurable `covdir` for pcache test runs
- gather pcache gcov data and reset gcov before module reloads

## Testing
- `avocado run --max-parallel-tasks 1 -m ./pcache.py.data/pcache.yaml -- ./pcache.py` *(fails: 80)*

------
https://chatgpt.com/codex/tasks/task_e_688eb1eee19c8321a7a1ca1ef52f9fbc