### PR TITLE
Use dm-delay backing device in pcache recreate loop

### DIFF
--- a/pcache.py.data/pcache_recreate_loop.sh
+++ b/pcache.py.data/pcache_recreate_loop.sh
@@ -51,6 +51,9 @@ fi
 sudo dmsetup remove "${dm_name}_probe"
 
 SEC_NR=$(sudo blockdev --getsz ${data_dev0})
+sudo dmsetup create data_delay --table \
+    "0 ${SEC_NR} delay ${data_dev0} 0 0 ${data_dev0} 0 5000"
+data_dev0="/dev/mapper/data_delay"
 dmesg_line=$(sudo dmesg | wc -l)
 for i in $(seq 1 ${iterations}); do
     sudo dmsetup create "${dm_name}" --table "0 ${SEC_NR} pcache ${cache_dev0} ${data_dev0} 4 cache_mode ${cache_mode} data_crc ${data_crc}"
@@ -70,6 +73,8 @@ for i in $(seq 1 ${iterations}); do
     sleep 1
 
 done
+
+sudo dmsetup remove data_delay
 
 pcache_rmmod
 new_dmesg_line=$(sudo dmesg | wc -l)


### PR DESCRIPTION
## Summary
- add a dm-delay mapping around the data device in `pcache_recreate_loop.sh`
- remove temporary delay device after test loop

## Testing
- `bash -n pcache.py.data/pcache_recreate_loop.sh`
- `shellcheck pcache.py.data/pcache_recreate_loop.sh`


------
https://chatgpt.com/codex/tasks/task_e_689319ab92f0832181f4a96a78529bec