### PR TITLE
Add optional 32-bit pcache build scenario

### DIFF
--- a/pcache.py.data/pcache.yaml
+++ b/pcache.py.data/pcache.yaml
@@ -1,5 +1,6 @@
 ---
 linux_path: "/workspace/linux_compile"
+kernel_dir_32: "/workspace_data/linux_compile_32/"
 covdir: "/workspace/datatravelguide/covdir"
 gcov: false
 cache_dev0: "/dev/pmem0"

--- a/pcache.py.data/pcache_build.sh
+++ b/pcache.py.data/pcache_build.sh
@@ -2,6 +2,7 @@
 set -ex
 
 : "${linux_path:=/workspace/linux_compile}"
+: "${kernel_dir_32:=/workspace_data/linux_compile_32/}"
 
 pushd "$linux_path"
 cleanup() {
@@ -15,4 +16,13 @@ make clean M=drivers/md/dm-pcache
 make M=drivers/md/dm-pcache/  C=2 CHECK="/workspace/smatch/smatch -p=kernel --full-path" -j 32 2>&1 | tee smatch.out
 grep -Ei 'warn|error' smatch.out && exit 1
 make htmldocs SPHINXDIRS=admin-guide/device-mapper SPHINXOPTS="-W -n -j1 --keep-going -D suppress_warnings=ref.doc"
+
+if [ -d "$kernel_dir_32" ]; then
+    pushd "$kernel_dir_32"
+    make clean M=drivers/md/dm-pcache/
+    make -j 64 ARCH=i386 M=drivers/md/dm-pcache/
+    popd
+else
+    echo "kernel_dir_32 not found ($kernel_dir_32), skipping 32-bit build."
+fi
 


### PR DESCRIPTION
## Summary
- extend pcache build script to optionally compile dm-pcache for 32-bit kernels
- allow configuring `kernel_dir_32` in pcache tests

## Testing
- `bash -n pcache.py.data/pcache_build.sh`
- `python -m py_compile pcache.py`


------
https://chatgpt.com/codex/tasks/task_e_68a7cc8de2a083219df922e99a0180e9