### PR TITLE
pcache: add checkpatch test case

### DIFF
--- a/pcache.py.data/pcache_misc_tests/case20_checkpatch.sh
+++ b/pcache.py.data/pcache_misc_tests/case20_checkpatch.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -ex
+
+: "${linux_path:=/workspace/linux_compile}"
+
+cd "${linux_path}"
+
+for file in $(git ls-files drivers/md/dm-pcache/); do
+    ./scripts/checkpatch.pl --fix-inplace "$file"
+    if [[ $? -ne 0 ]]; then
+        echo "checkpatch failed for $file"
+        exit 1
+    fi
+done
+


### PR DESCRIPTION
## Summary
- add a misc test that runs `checkpatch.pl` with `--fix-inplace` on `dm-pcache` sources and exits on style errors

## Testing
- `bash pcache.py.data/pcache_misc_tests/case20_checkpatch.sh` *(fails: pcache.py.data/pcache_misc_tests/case20_checkpatch.sh: line 6: cd: /workspace/linux_compile: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b509dd36ac83218a37d71eece26efe